### PR TITLE
feat: Invitation dialog

### DIFF
--- a/packages/apptive_grid_heinzelmen/README.md
+++ b/packages/apptive_grid_heinzelmen/README.md
@@ -102,3 +102,12 @@ const ProfilePicture({
     name: 'Christian Denker',
   })
 ```
+
+## InvitationDialog
+Show a Dialog to invite someone to a Space
+
+```dart
+showSpaceInvitationDialog(context: context, space: space);
+```
+
+The available Roles and Invitation Method (Invitation, Direct Add) can be configured as well as all Strings. For more Details check the code Documentation

--- a/packages/apptive_grid_heinzelmen/lib/apptive_grid_heinzelmen.dart
+++ b/packages/apptive_grid_heinzelmen/lib/apptive_grid_heinzelmen.dart
@@ -5,4 +5,5 @@ export 'package:apptive_grid_heinzelmen/src/attachment_image.dart';
 export 'package:apptive_grid_heinzelmen/src/configuration.dart';
 export 'package:apptive_grid_heinzelmen/src/data_widget/data_widget.dart';
 export 'package:apptive_grid_heinzelmen/src/data_widget/profile_picture.dart';
+export 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_dialog.dart';
 export 'package:apptive_grid_heinzelmen/src/stage_banner.dart';

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_dialog.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_dialog.dart
@@ -53,10 +53,10 @@ Future<bool> showSpaceInvitationDialog({
           child: AlertDialog(
             title: Text.rich(
               TextSpan(
-                children: getSpans(
+                children: getHighlightSpans(
                   getText: l10n.title,
-                  argument: space.name,
-                  style: TextStyle(
+                  highlight: space.name,
+                  highlightStyle: TextStyle(
                     color: Theme.of(context).colorScheme.primary,
                   ),
                 ),
@@ -91,15 +91,19 @@ Future<bool> showSpaceInvitationDialog({
   ).then((_) => dialogResult);
 }
 
-/// Returns a List of [TextSpans] that format [argument] with [style] and use default styles for other text that was generated with [getText]
+/// Returns a List of [TextSpans] that format [highlight] with [highlightStyle]
+/// This will call [getText] with [highlight] to get a String where [highlight] can be substituted in
+/// It will return a List of [TextSpan] where the first occurrence of [highlight] has [highlightStyle] as the applied style
+/// If [highlight] appears in [getText] but is not the substituted value this will not be counted as the first occurrence
+/// Only the first [highlight] will be styled with [highlightStyle]
 @visibleForTesting
-List<TextSpan> getSpans({
+List<TextSpan> getHighlightSpans({
   required String Function(String) getText,
-  required String argument,
-  required TextStyle style,
+  required String highlight,
+  required TextStyle highlightStyle,
 }) {
   final emptyTitle = getText('');
-  final realTitle = getText(argument);
+  final realTitle = getText(highlight);
 
   if (realTitle.length == emptyTitle.length) {
     return [TextSpan(text: realTitle)];
@@ -113,9 +117,9 @@ List<TextSpan> getSpans({
     }
     return [
       if (startIndex != 0) TextSpan(text: realTitle.substring(0, startIndex)),
-      TextSpan(text: argument, style: style),
-      if (startIndex + argument.length < realTitle.length)
-        TextSpan(text: realTitle.substring(startIndex + argument.length)),
+      TextSpan(text: highlight, style: highlightStyle),
+      if (startIndex + highlight.length < realTitle.length)
+        TextSpan(text: realTitle.substring(startIndex + highlight.length)),
     ];
   }
 }
@@ -309,10 +313,11 @@ class _InvitationSendButtonState extends State<_InvitationSendButton> {
               SnackBar(
                 content: Text.rich(
                   TextSpan(
-                    children: getSpans(
+                    children: getHighlightSpans(
                       getText: widget.localization.inviteSend,
-                      argument: widget.email.text,
-                      style: const TextStyle(fontWeight: FontWeight.bold),
+                      highlight: widget.email.text,
+                      highlightStyle:
+                          const TextStyle(fontWeight: FontWeight.bold),
                     ),
                   ),
                 ),

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_dialog.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_dialog.dart
@@ -177,7 +177,6 @@ class _InvitationDialogContent extends StatelessWidget {
                     selectedItemBuilder: (_) => allowedRoles
                         .map(
                           (role) => ListTile(
-                            horizontalTitleGap: 0,
                             contentPadding: EdgeInsets.zero,
                             title: Text(_roleTitle(role)),
                           ),
@@ -190,8 +189,7 @@ class _InvitationDialogContent extends StatelessWidget {
                             child: ListTile(
                               title: Text(_roleTitle(role)),
                               subtitle: Text(_roleSubTitle(role)),
-                              isThreeLine: true,
-                              horizontalTitleGap: 0,
+                              contentPadding: EdgeInsets.zero,
                             ),
                           ),
                         )

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_dialog.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_dialog.dart
@@ -1,0 +1,279 @@
+import 'package:apptive_grid_core/apptive_grid_core.dart';
+import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_l10n_de.dart';
+import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_l10n_en.dart';
+import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart';
+
+export 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_localization.dart';
+
+Future showSpaceInvitationDialog({
+  required BuildContext context,
+  required Space space,
+  List<Role> allowedRoles = Role.values,
+  ApptiveLinkType type = ApptiveLinkType.invite,
+  InvitationLocalization? localization,
+}) async {
+  assert(type == ApptiveLinkType.invite || type == ApptiveLinkType.addShare);
+  assert(space.links.containsKey(type));
+  assert(allowedRoles.isNotEmpty);
+
+  final l10n = localization ??
+      (Localizations.localeOf(context).languageCode == 'de'
+          ? InvitationLocalizationDE()
+          : InvitationLocalizationEn());
+
+  TextEditingController _emailController = TextEditingController();
+  ValueNotifier<Role> _roleNotifier = ValueNotifier(allowedRoles.first);
+  ValueNotifier<bool> _loading = ValueNotifier(false);
+  return showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder: (dialogContext) {
+      return ValueListenableBuilder<bool>(
+        valueListenable: _loading,
+        builder: (_, loading, child) => IgnorePointer(
+          ignoring: loading,
+          child: child,
+        ),
+        child: Form(
+          child: AlertDialog(
+            title: Text.rich(
+              TextSpan(
+                children: getSpans(
+                  getText: l10n.title,
+                  argument: space.name,
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                ),
+              ),
+            ),
+            content: _InvitationDialogContent(
+              emailController: _emailController,
+              role: _roleNotifier,
+              allowedRoles: allowedRoles,
+              localization: l10n,
+            ),
+            actions: [
+              TextButton(
+                onPressed: Navigator.of(dialogContext).pop,
+                child: Text(l10n.actionCancel),
+              ),
+              _InvitationSendButton(
+                  loading: _loading,
+                  role: _roleNotifier,
+                  localization: l10n,
+                  email: _emailController,
+                  link: space.links[type]!),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}
+
+@visibleForTesting
+List<TextSpan> getSpans({
+  required String Function(String) getText,
+  required String argument,
+  required TextStyle style,
+}) {
+  final emptyTitle = getText('');
+  final realTitle = getText(argument);
+
+  if (realTitle.length == emptyTitle.length) {
+    return [TextSpan(text: realTitle)];
+  } else {
+    late int startIndex;
+    for (int i = 0; i < emptyTitle.length; i++) {
+      if (realTitle[i] != emptyTitle[i]) {
+        startIndex = i;
+        break;
+      }
+    }
+    return [
+      TextSpan(text: realTitle.substring(0, startIndex)),
+      TextSpan(text: argument, style: style),
+      TextSpan(text: realTitle.substring(startIndex + argument.length)),
+    ];
+  }
+}
+
+class _InvitationDialogContent extends StatelessWidget {
+  const _InvitationDialogContent(
+      {Key? key,
+      required this.emailController,
+      required this.role,
+      required this.allowedRoles,
+      required this.localization})
+      : super(key: key);
+
+  final TextEditingController emailController;
+  final ValueNotifier<Role> role;
+  final List<Role> allowedRoles;
+  final InvitationLocalization localization;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<Role>(
+      valueListenable: role,
+      builder: (context, role, _) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(localization.message),
+            Padding(
+              padding: EdgeInsets.symmetric(vertical: 8),
+              child: TextFormField(
+                controller: emailController,
+                validator: (value) {
+                  if (!RegExp(r'^\S+@\S+\.\S+$').hasMatch(value ?? '')) {
+                    return localization.nonValidEmail;
+                  } else {
+                    return null;
+                  }
+                },
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+                decoration: InputDecoration(
+                  hintText: localization.hintEmail,
+                ),
+              ),
+            ),
+            if (allowedRoles.length > 1)
+              Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: DropdownButton<Role>(
+                  value: role,
+                  isExpanded: true,
+                  itemHeight: null,
+                  selectedItemBuilder: (_) => allowedRoles
+                      .map((role) => ListTile(title: Text(_roleTitle(role))))
+                      .toList(),
+                  items: allowedRoles
+                      .map((role) => DropdownMenuItem(
+                          value: role,
+                          child: ListTile(
+                            title: Text(_roleTitle(role)),
+                            subtitle: Text(_roleSubTitle(role)),
+                            isThreeLine: true,
+                          )))
+                      .toList(),
+                  onChanged: (newRole) {
+                    if (newRole != null) {
+                      this.role.value = newRole;
+                    }
+                  },
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
+  String _roleTitle(Role role) {
+    switch (role) {
+      case Role.admin:
+        return localization.roleAdmin;
+      case Role.reader:
+        return localization.roleReader;
+      case Role.writer:
+        return localization.roleWriter;
+    }
+  }
+
+  String _roleSubTitle(Role role) {
+    switch (role) {
+      case Role.admin:
+        return localization.roleDescriptionAdmin;
+      case Role.reader:
+        return localization.roleDescriptionReader;
+      case Role.writer:
+        return localization.roleDescriptionWriter;
+    }
+  }
+}
+
+class _InvitationSendButton extends StatefulWidget {
+  const _InvitationSendButton(
+      {Key? key,
+      required this.loading,
+      required this.role,
+      required this.localization,
+      required this.email,
+      required this.link})
+      : super(key: key);
+
+  final ValueNotifier<bool> loading;
+  final ValueNotifier<Role> role;
+  final InvitationLocalization localization;
+  final TextEditingController email;
+  final ApptiveLink link;
+
+  @override
+  State<_InvitationSendButton> createState() => _InvitationSendButtonState();
+}
+
+class _InvitationSendButtonState extends State<_InvitationSendButton> {
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: widget.loading,
+      builder: (context, loading, _) {
+        return TextButton(
+            onPressed: _send,
+            child: loading
+                ? const SizedBox(
+                    width: 32,
+                    height: 16,
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 8.0),
+                      child: CircularProgressIndicator.adaptive(
+                        strokeWidth: 2,
+                      ),
+                    ),
+                  )
+                : Text(widget.localization.actionSend));
+      },
+    );
+  }
+
+  Future<void> _send() async {
+    FocusScope.of(context).requestFocus(FocusNode());
+
+    if (Form.of(context).validate()) {
+      final client = ApptiveGrid.getClient(context, listen: false);
+      widget.loading.value = true;
+      try {
+        final email = widget.email.text;
+        await client.performApptiveLink<bool>(
+            link: widget.link,
+            body: {
+              'email': email,
+              'role': widget.role.value.backendName,
+            },
+            parseResponse: (response) async {
+              widget.email.clear();
+              Form.of(context).reset();
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                  content: Text.rich(TextSpan(
+                      children: getSpans(
+                          getText: widget.localization.inviteSend,
+                          argument: widget.email.text,
+                          style: TextStyle(fontWeight: FontWeight.bold))))));
+              return response.statusCode < 300;
+            });
+      } catch (error) {
+        debugPrint('Error: $error');
+        if (error is Response) {
+          debugPrint('Body: ${error.body}');
+        }
+      } finally {
+        widget.loading.value = false;
+      }
+    }
+  }
+}

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_dialog.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_dialog.dart
@@ -41,7 +41,6 @@ Future<bool> showSpaceInvitationDialog({
   bool dialogResult = false;
   return showDialog(
     context: context,
-    barrierDismissible: false,
     builder: (dialogContext) {
       return ValueListenableBuilder<bool>(
         valueListenable: loading,
@@ -78,7 +77,25 @@ Future<bool> showSpaceInvitationDialog({
                 loading: loading,
                 role: roleNotifier,
                 error: errorNotifier,
-                onInviteSend: (value) => dialogResult = value,
+                onInviteSend: (email) {
+                  dialogResult = true;
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text.rich(
+                          TextSpan(
+                            children: getHighlightSpans(
+                              getText: l10n.inviteSend,
+                              highlight: email,
+                              highlightStyle:
+                                  const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                          ),
+                        ),
+                      ),
+                    );
+                  }
+                },
                 localization: l10n,
                 email: emailController,
                 link: space.links[type]!,
@@ -256,7 +273,9 @@ class _InvitationSendButton extends StatefulWidget {
   final ValueNotifier<bool> loading;
   final ValueNotifier<Role> role;
   final ValueNotifier<dynamic> error;
-  final void Function(bool) onInviteSend;
+
+  /// Callback with the email address that the invite was send to
+  final void Function(String) onInviteSend;
   final InvitationLocalization localization;
   final TextEditingController email;
   final ApptiveLink link;
@@ -306,23 +325,9 @@ class _InvitationSendButtonState extends State<_InvitationSendButton> {
             'role': widget.role.value.backendName,
           },
           parseResponse: (response) async {
+            widget.onInviteSend(email);
             widget.email.clear();
             Form.of(context).reset();
-            widget.onInviteSend(true);
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text.rich(
-                  TextSpan(
-                    children: getHighlightSpans(
-                      getText: widget.localization.inviteSend,
-                      highlight: widget.email.text,
-                      highlightStyle:
-                          const TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                  ),
-                ),
-              ),
-            );
             return response.statusCode < 300;
           },
         );

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_de.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_de.dart
@@ -1,3 +1,5 @@
+// coverage:ignore-file
+
 import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_localization.dart';
 
 class InvitationLocalizationDE extends InvitationLocalization {

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_de.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_de.dart
@@ -1,0 +1,47 @@
+import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_localization.dart';
+
+class InvitationLocalizationDE extends InvitationLocalization {
+  const InvitationLocalizationDE() : super();
+
+  @override
+  String get actionCancel => 'Abbrechen';
+
+  @override
+  String get actionSend => 'Senden';
+
+  @override
+  String get hintEmail => 'E-Mail';
+
+  @override
+  String get nonValidEmail => 'Gültige E-Mail Adresse notwendig';
+
+  @override
+  String get message => 'Laden Sie Ihr Team zu diesem Space ein';
+
+  @override
+  String get roleAdmin => 'Managen';
+
+  @override
+  String get roleReader => 'Nur ansehen';
+
+  @override
+  String get roleWriter => 'Einträge bearbeiten';
+
+  @override
+  String get roleDescriptionAdmin =>
+      'diesen Space bearbeiten und konfigurieren';
+
+  @override
+  String get roleDescriptionReader =>
+      'Inhalte bearbeiten aber nichts konfigurieren';
+
+  @override
+  String get roleDescriptionWriter =>
+      'den Space nicht bearbeiten und konfigurieren';
+
+  @override
+  String title(String spaceName) => 'Teilen Sie $spaceName mit anderen';
+
+  @override
+  String inviteSend(String email) => 'Einladung an $email wurde gesendet';
+}

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_de.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_de.dart
@@ -2,7 +2,9 @@
 
 import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_localization.dart';
 
+/// German Translations for [InvitationLocalization]
 class InvitationLocalizationDE extends InvitationLocalization {
+  /// Const constructor to call super
   const InvitationLocalizationDE() : super();
 
   @override

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_en.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_en.dart
@@ -1,3 +1,5 @@
+// coverage:ignore-file
+
 import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_localization.dart';
 
 class InvitationLocalizationEn extends InvitationLocalization {

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_en.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_en.dart
@@ -1,0 +1,44 @@
+import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_localization.dart';
+
+class InvitationLocalizationEn extends InvitationLocalization {
+  const InvitationLocalizationEn() : super();
+
+  @override
+  String get actionCancel => 'Cancel';
+
+  @override
+  String get actionSend => 'Send';
+
+  @override
+  String get hintEmail => 'Email';
+
+  @override
+  String get nonValidEmail => 'Valid email address necessary';
+
+  @override
+  String get message => 'Invite your team to this space';
+
+  @override
+  String get roleAdmin => 'Manage';
+
+  @override
+  String get roleReader => 'Read only';
+
+  @override
+  String get roleWriter => 'Edit entries';
+
+  @override
+  String get roleDescriptionAdmin => 'Fully edit and configure that space';
+
+  @override
+  String get roleDescriptionReader => 'Not edit or configure that space';
+
+  @override
+  String get roleDescriptionWriter => 'Edit Entries but not edit that space';
+
+  @override
+  String title(String spaceName) => 'Share $spaceName with others';
+
+  @override
+  String inviteSend(String email) => 'We send an invite to $email.';
+}

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_en.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_l10n_en.dart
@@ -2,7 +2,9 @@
 
 import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_localization.dart';
 
+/// English Translations for [InvitationLocalization]
 class InvitationLocalizationEn extends InvitationLocalization {
+  /// Const constructor to call super
   const InvitationLocalizationEn() : super();
 
   @override

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_localization.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_localization.dart
@@ -1,0 +1,29 @@
+abstract class InvitationLocalization {
+  const InvitationLocalization();
+
+  String title(String spaceName);
+
+  String get message;
+
+  String get hintEmail;
+
+  String get nonValidEmail;
+
+  String get roleAdmin;
+
+  String get roleReader;
+
+  String get roleWriter;
+
+  String get roleDescriptionAdmin;
+
+  String get roleDescriptionReader;
+
+  String get roleDescriptionWriter;
+
+  String get actionCancel;
+
+  String get actionSend;
+
+  String inviteSend(String email);
+}

--- a/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_localization.dart
+++ b/packages/apptive_grid_heinzelmen/lib/src/invitation_dialog/invitation_localization.dart
@@ -1,29 +1,46 @@
+/// Translations for [InvitationDialog]
 abstract class InvitationLocalization {
+  /// Const Constructor
   const InvitationLocalization();
 
+  /// A Title for the dialog that will be called with [spaceName] which is the Name of the Space that shoul;d be shared
+  /// [spaceName] will be colored in the theme's primary color
   String title(String spaceName);
 
+  /// A description message in the dialog
   String get message;
 
+  /// Hint for the Email Input
   String get hintEmail;
 
+  /// Message when the Entered Email is not a valid email address
   String get nonValidEmail;
 
+  /// Label for Admin Role
   String get roleAdmin;
 
+  /// Label for Reader Role
   String get roleReader;
 
+  /// Label for Writer Role
   String get roleWriter;
 
+  /// Description for Admin Role
   String get roleDescriptionAdmin;
 
+  /// Description for Reader Role
   String get roleDescriptionReader;
 
+  /// Description for Writer Role
   String get roleDescriptionWriter;
 
+  /// Label for cancel Button
   String get actionCancel;
 
+  /// Label for send button
   String get actionSend;
 
+  /// A message that will be displayed in a SnackBar after an invite was send
+  /// [email] is the email that was invited. It will be formatted bold
   String inviteSend(String email);
 }

--- a/packages/apptive_grid_heinzelmen/pubspec.yaml
+++ b/packages/apptive_grid_heinzelmen/pubspec.yaml
@@ -8,17 +8,10 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
   flutter: ">=1.17.0"
 
-dependency_overrides:
-  apptive_grid_core:
-    git:
-      url: https://github.com/ApptiveGrid/ApptiveGrid-flutter
-      ref: space-invitations
-      path: packages/apptive_grid_core
-
 dependencies:
-  apptive_grid_core: ^1.0.0
-  apptive_grid_user_management: ^1.0.0
-  apptive_grid_theme: ^1.0.0
+  apptive_grid_core: ^1.3.0
+  apptive_grid_user_management: ^1.1.2
+  apptive_grid_theme: ^1.1.0
   flutter:
     sdk: flutter
   flutter_svg: ^1.1.1+1
@@ -26,7 +19,7 @@ dependencies:
   intl: ^0.17.0
   provider: ^6.0.3
   universal_file: ^1.0.0
-  zweidenker_heinzelmen: ^0.0.3
+  zweidenker_heinzelmen: ^1.0.0
 
 dev_dependencies:
   alchemist: ^0.6.0

--- a/packages/apptive_grid_heinzelmen/pubspec.yaml
+++ b/packages/apptive_grid_heinzelmen/pubspec.yaml
@@ -8,6 +8,13 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
   flutter: ">=1.17.0"
 
+dependency_overrides:
+  apptive_grid_core:
+    git:
+      url: https://github.com/ApptiveGrid/ApptiveGrid-flutter
+      ref: space-invitations
+      path: packages/apptive_grid_core
+
 dependencies:
   apptive_grid_core: ^1.0.0
   apptive_grid_user_management: ^1.0.0
@@ -15,6 +22,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^1.1.1+1
+  http: ^0.13.5
   intl: ^0.17.0
   provider: ^6.0.3
   universal_file: ^1.0.0
@@ -25,6 +33,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.1
+  flutter_localizations:
+    sdk: flutter
   golden_toolkit: ^0.13.0
   mocktail: ^0.3.0
   mocktail_image_network: ^0.3.1

--- a/packages/apptive_grid_heinzelmen/test/infra/mocks.dart
+++ b/packages/apptive_grid_heinzelmen/test/infra/mocks.dart
@@ -1,4 +1,7 @@
+import 'package:apptive_grid_core/apptive_grid_core.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:zweidenker_heinzelmen/zweidenker_heinzelmen.dart';
 
 class MockLinkLauncher extends Mock implements LinkLauncher {}
+
+class MockApptiveGridClient extends Mock implements ApptiveGridClient {}

--- a/packages/apptive_grid_heinzelmen/test/src/invitation_dialog/invitation_dialog_test.dart
+++ b/packages/apptive_grid_heinzelmen/test/src/invitation_dialog/invitation_dialog_test.dart
@@ -15,10 +15,10 @@ void main() {
     const style = TextStyle(fontWeight: FontWeight.bold);
 
     test('Substitute not in result returns single Span', () {
-      final spans = getSpans(
+      final spans = getHighlightSpans(
         getText: (_) => 'No Content',
-        argument: 'spaceName',
-        style: style,
+        highlight: 'spaceName',
+        highlightStyle: style,
       );
 
       expect(spans.length, 1);
@@ -26,10 +26,10 @@ void main() {
     });
 
     test('Substitute is first element returns two Spans', () {
-      final spans = getSpans(
+      final spans = getHighlightSpans(
         getText: (value) => '$value Content',
-        argument: 'value',
-        style: style,
+        highlight: 'value',
+        highlightStyle: style,
       );
 
       expect(spans.length, 2);
@@ -40,10 +40,10 @@ void main() {
     });
 
     test('Substitute is last element returns two Spans', () {
-      final spans = getSpans(
+      final spans = getHighlightSpans(
         getText: (value) => 'Content $value',
-        argument: 'value',
-        style: style,
+        highlight: 'value',
+        highlightStyle: style,
       );
 
       expect(spans.length, 2);
@@ -55,10 +55,10 @@ void main() {
 
     test('Space Name gets Substituted', () {
       const spaceName = 'spaceName';
-      final spans = getSpans(
+      final spans = getHighlightSpans(
         getText: const InvitationLocalizationEn().title,
-        argument: spaceName,
-        style: style,
+        highlight: spaceName,
+        highlightStyle: style,
       );
 
       expect(spans.length, 3);
@@ -72,10 +72,10 @@ void main() {
 
     test('Space Name occurs before substitution, is substituted correctly', () {
       const spaceName = 'Share ';
-      final spans = getSpans(
+      final spans = getHighlightSpans(
         getText: const InvitationLocalizationEn().title,
-        argument: spaceName,
-        style: style,
+        highlight: spaceName,
+        highlightStyle: style,
       );
 
       expect(spans.length, 3);
@@ -89,10 +89,10 @@ void main() {
 
     test('Space Name occurs after substitution, is substituted correctly', () {
       const spaceName = 'others';
-      final spans = getSpans(
+      final spans = getHighlightSpans(
         getText: const InvitationLocalizationEn().title,
-        argument: spaceName,
-        style: style,
+        highlight: spaceName,
+        highlightStyle: style,
       );
 
       expect(spans.length, 3);

--- a/packages/apptive_grid_heinzelmen/test/src/invitation_dialog/invitation_dialog_test.dart
+++ b/packages/apptive_grid_heinzelmen/test/src/invitation_dialog/invitation_dialog_test.dart
@@ -1,0 +1,680 @@
+import 'package:apptive_grid_core/apptive_grid_core.dart';
+import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_dialog.dart';
+import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_l10n_de.dart';
+import 'package:apptive_grid_heinzelmen/src/invitation_dialog/invitation_l10n_en.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../infra/mocks.dart';
+
+void main() {
+  group('Get Spans', () {
+    const style = TextStyle(fontWeight: FontWeight.bold);
+
+    test('Substitute not in result returns single Span', () {
+      final spans = getSpans(
+        getText: (_) => 'No Content',
+        argument: 'spaceName',
+        style: style,
+      );
+
+      expect(spans.length, 1);
+      expect(spans.first.text, 'No Content');
+    });
+
+    test('Substitute is first element returns two Spans', () {
+      final spans = getSpans(
+        getText: (value) => '$value Content',
+        argument: 'value',
+        style: style,
+      );
+
+      expect(spans.length, 2);
+      expect(spans[0].text, 'value');
+      expect(spans[0].style, style);
+      expect(spans[1].text, ' Content');
+      expect(spans[1].style, isNull);
+    });
+
+    test('Substitute is last element returns two Spans', () {
+      final spans = getSpans(
+        getText: (value) => 'Content $value',
+        argument: 'value',
+        style: style,
+      );
+
+      expect(spans.length, 2);
+      expect(spans[1].text, 'value');
+      expect(spans[1].style, style);
+      expect(spans[0].text, 'Content ');
+      expect(spans[0].style, isNull);
+    });
+
+    test('Space Name gets Substituted', () {
+      const spaceName = 'spaceName';
+      final spans = getSpans(
+        getText: const InvitationLocalizationEn().title,
+        argument: spaceName,
+        style: style,
+      );
+
+      expect(spans.length, 3);
+      expect(spans[0].text, 'Share ');
+      expect(spans[0].style, isNull);
+      expect(spans[1].text, spaceName);
+      expect(spans[1].style, style);
+      expect(spans[2].text, ' with others');
+      expect(spans[2].style, isNull);
+    });
+
+    test('Space Name occurs before substitution, is substituted correctly', () {
+      const spaceName = 'Share ';
+      final spans = getSpans(
+        getText: const InvitationLocalizationEn().title,
+        argument: spaceName,
+        style: style,
+      );
+
+      expect(spans.length, 3);
+      expect(spans[0].text, 'Share ');
+      expect(spans[0].style, isNull);
+      expect(spans[1].text, spaceName);
+      expect(spans[1].style, style);
+      expect(spans[2].text, ' with others');
+      expect(spans[2].style, isNull);
+    });
+
+    test('Space Name occurs after substitution, is substituted correctly', () {
+      const spaceName = 'others';
+      final spans = getSpans(
+        getText: const InvitationLocalizationEn().title,
+        argument: spaceName,
+        style: style,
+      );
+
+      expect(spans.length, 3);
+      expect(spans[0].text, 'Share ');
+      expect(spans[0].style, isNull);
+      expect(spans[1].text, spaceName);
+      expect(spans[1].style, style);
+      expect(spans[2].text, ' with others');
+      expect(spans[2].style, isNull);
+    });
+  });
+
+  group('Dialog', () {
+    late ApptiveGridClient client;
+
+    late BuildContext context;
+
+    late Widget target;
+
+    final inviteLink = ApptiveLink(uri: Uri(path: '/invite'), method: 'post');
+    final addShareLink =
+        ApptiveLink(uri: Uri(path: '/addShare'), method: 'post');
+
+    const spaceName = 'Space';
+
+    final space = Space(
+      id: 'id',
+      name: spaceName,
+      links: {
+        ApptiveLinkType.invite: inviteLink,
+        ApptiveLinkType.addShare: addShareLink,
+      },
+    );
+
+    const email = 'test@apptivegrid.de';
+
+    setUp(() {
+      client = MockApptiveGridClient();
+
+      target = ApptiveGrid.withClient(
+        client: client,
+        child: MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (buildContext) {
+                context = buildContext;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+    });
+
+    testWidgets('Show Dialog', (tester) async {
+      await tester.pumpWidget(target);
+      await tester.pumpAndSettle();
+
+      showSpaceInvitationDialog(context: context, space: space);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+    });
+
+    testWidgets('Cancel pops dialog', (tester) async {
+      await tester.pumpWidget(target);
+      await tester.pumpAndSettle();
+
+      showSpaceInvitationDialog(context: context, space: space);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+
+    testWidgets('No email shows error', (tester) async {
+      await tester.pumpWidget(target);
+      await tester.pumpAndSettle();
+
+      showSpaceInvitationDialog(context: context, space: space);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Valid email address necessary'), findsOneWidget);
+    });
+
+    testWidgets('Invalid Email shows hint', (tester) async {
+      await tester.pumpWidget(target);
+      await tester.pumpAndSettle();
+
+      showSpaceInvitationDialog(context: context, space: space);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField), 'invalid@email');
+
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Valid email address necessary'), findsOneWidget);
+    });
+
+    testWidgets('Default calls invite', (tester) async {
+      when(
+        () => client.performApptiveLink<bool>(
+          link: inviteLink,
+          body: {
+            'email': email,
+            'role': Role.admin.backendName,
+          },
+          parseResponse: any(named: 'parseResponse'),
+        ),
+      ).thenAnswer((invocation) async {
+        final parser = invocation.namedArguments[const Symbol('parseResponse')]
+            as Future<bool> Function(Response);
+
+        return parser(Response('Invitation send', 200));
+      });
+      await tester.pumpWidget(target);
+      await tester.pumpAndSettle();
+
+      showSpaceInvitationDialog(context: context, space: space);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField), email);
+
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => client.performApptiveLink<bool>(
+          link: inviteLink,
+          body: {
+            'email': email,
+            'role': Role.admin.backendName,
+          },
+          parseResponse: any(named: 'parseResponse'),
+        ),
+      ).called(1);
+    });
+
+    testWidgets('Success clears field', (tester) async {
+      when(
+        () => client.performApptiveLink<bool>(
+          link: inviteLink,
+          body: {
+            'email': email,
+            'role': Role.admin.backendName,
+          },
+          parseResponse: any(named: 'parseResponse'),
+        ),
+      ).thenAnswer((invocation) async {
+        final parser = invocation.namedArguments[const Symbol('parseResponse')]
+            as Future<bool> Function(Response);
+
+        return parser(Response('Invitation send', 200));
+      });
+      await tester.pumpWidget(target);
+      await tester.pumpAndSettle();
+
+      showSpaceInvitationDialog(context: context, space: space);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField), email);
+
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(email), findsNothing);
+      expect(
+        (find.byType(TextFormField).evaluate().first.widget as TextFormField)
+            .controller!
+            .text,
+        equals(''),
+      );
+    });
+
+    testWidgets('Add Share as type calls add share', (tester) async {
+      when(
+        () => client.performApptiveLink<bool>(
+          link: addShareLink,
+          body: {
+            'email': email,
+            'role': Role.admin.backendName,
+          },
+          parseResponse: any(named: 'parseResponse'),
+        ),
+      ).thenAnswer((invocation) async {
+        final parser = invocation.namedArguments[const Symbol('parseResponse')]
+            as Future<bool> Function(Response);
+
+        return parser(Response('Invitation send', 200));
+      });
+      await tester.pumpWidget(target);
+      await tester.pumpAndSettle();
+
+      showSpaceInvitationDialog(
+        context: context,
+        space: space,
+        type: ApptiveLinkType.addShare,
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField), email);
+
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => client.performApptiveLink<bool>(
+          link: addShareLink,
+          body: {
+            'email': email,
+            'role': Role.admin.backendName,
+          },
+          parseResponse: any(named: 'parseResponse'),
+        ),
+      ).called(1);
+    });
+
+    group('Localization', () {
+      testWidgets('Locale is German uses German translation', (tester) async {
+        await tester.pumpWidget(ApptiveGrid.withClient(
+          client: client,
+          child: MaterialApp(
+            locale: Locale('de'),
+            supportedLocales: [Locale('de')],
+            localizationsDelegates: [
+              DefaultWidgetsLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            home: Builder(
+              builder: (buildContext) {
+                context = buildContext;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        showSpaceInvitationDialog(context: context, space: space);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Senden'), findsOneWidget);
+      });
+      testWidgets('Override with custom Localization', (tester) async {
+        await tester.pumpWidget(target);
+        await tester.pumpAndSettle();
+
+        showSpaceInvitationDialog(
+            context: context,
+            space: space,
+            localization: InvitationLocalizationDE());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Senden'), findsOneWidget);
+      });
+    });
+
+    group('Error', () {
+      testWidgets('Error is shown and keeps field value', (tester) async {
+        when(
+          () => client.performApptiveLink<bool>(
+            link: inviteLink,
+            body: {
+              'email': email,
+              'role': Role.admin.backendName,
+            },
+            parseResponse: any(named: 'parseResponse'),
+          ),
+        ).thenAnswer((invocation) async => Future.error('error'));
+        await tester.pumpWidget(target);
+        await tester.pumpAndSettle();
+
+        showSpaceInvitationDialog(context: context, space: space);
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextFormField), email);
+
+        await tester.tap(find.text('Send'));
+        await tester.pumpAndSettle();
+
+        expect(find.text(email), findsOneWidget);
+        expect(find.text('error'), findsOneWidget);
+        expect(
+          (find.byType(TextFormField).evaluate().first.widget as TextFormField)
+              .controller!
+              .text,
+          equals(email),
+        );
+      });
+
+      testWidgets('Error Body has description shows error', (tester) async {
+        when(
+          () => client.performApptiveLink<bool>(
+            link: inviteLink,
+            body: {
+              'email': email,
+              'role': Role.admin.backendName,
+            },
+            parseResponse: any(named: 'parseResponse'),
+          ),
+        ).thenAnswer(
+          (invocation) async => Future.error(
+            Response(
+              '''{
+      "error" : "emailNotfound",
+      "description" : "User with email '$email' does not exist."
+      }''',
+              400,
+            ),
+          ),
+        );
+        await tester.pumpWidget(target);
+        await tester.pumpAndSettle();
+
+        showSpaceInvitationDialog(context: context, space: space);
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextFormField), email);
+
+        await tester.tap(find.text('Send'));
+        await tester.pumpAndSettle();
+
+        expect(find.text(email), findsOneWidget);
+        expect(
+          find.text("User with email '$email' does not exist."),
+          findsOneWidget,
+        );
+        expect(
+          (find.byType(TextFormField).evaluate().first.widget as TextFormField)
+              .controller!
+              .text,
+          equals(email),
+        );
+      });
+
+      testWidgets('Body Parsing fails shows response', (tester) async {
+        when(
+          () => client.performApptiveLink<bool>(
+            link: inviteLink,
+            body: {
+              'email': email,
+              'role': Role.admin.backendName,
+            },
+            parseResponse: any(named: 'parseResponse'),
+          ),
+        ).thenAnswer(
+          (invocation) async => Future.error(Response('''{''', 400)),
+        );
+        await tester.pumpWidget(target);
+        await tester.pumpAndSettle();
+
+        showSpaceInvitationDialog(context: context, space: space);
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextFormField), email);
+
+        await tester.tap(find.text('Send'));
+        await tester.pumpAndSettle();
+
+        expect(find.text(email), findsOneWidget);
+        expect(find.text("Instance of 'Response'"), findsOneWidget);
+        expect(
+          (find.byType(TextFormField).evaluate().first.widget as TextFormField)
+              .controller!
+              .text,
+          equals(email),
+        );
+      });
+
+      testWidgets('Error Body has no description shows body', (tester) async {
+        when(
+          () => client.performApptiveLink<bool>(
+            link: inviteLink,
+            body: {
+              'email': email,
+              'role': Role.admin.backendName,
+            },
+            parseResponse: any(named: 'parseResponse'),
+          ),
+        ).thenAnswer(
+          (invocation) async => Future.error(Response('"body"', 400)),
+        );
+        await tester.pumpWidget(target);
+        await tester.pumpAndSettle();
+
+        showSpaceInvitationDialog(context: context, space: space);
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextFormField), email);
+
+        await tester.tap(find.text('Send'));
+        await tester.pumpAndSettle();
+
+        expect(find.text(email), findsOneWidget);
+        expect(find.text('body'), findsOneWidget);
+        expect(
+          (find.byType(TextFormField).evaluate().first.widget as TextFormField)
+              .controller!
+              .text,
+          equals(email),
+        );
+      });
+    });
+
+    group('Roles', () {
+      testWidgets('Change Role is applied', (tester) async {
+        when(
+          () => client.performApptiveLink<bool>(
+            link: inviteLink,
+            body: any(named: 'body'),
+            parseResponse: any(named: 'parseResponse'),
+          ),
+        ).thenAnswer((invocation) async {
+          final parser =
+              invocation.namedArguments[const Symbol('parseResponse')]
+                  as Future<bool> Function(Response);
+
+          return parser(Response('Invitation send', 200));
+        });
+        await tester.pumpWidget(target);
+        await tester.pumpAndSettle();
+
+        showSpaceInvitationDialog(context: context, space: space);
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextFormField), email);
+
+        await tester.tap(find.text('Manage'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Read only').last);
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Send'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextFormField), email);
+
+        await tester.tap(find.text('Read only'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Edit entries').last);
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Send'));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => client.performApptiveLink<bool>(
+            link: inviteLink,
+            body: {
+              'email': email,
+              'role': Role.writer.backendName,
+            },
+            parseResponse: any(named: 'parseResponse'),
+          ),
+        ).called(1);
+
+        verify(
+          () => client.performApptiveLink<bool>(
+            link: inviteLink,
+            body: {
+              'email': email,
+              'role': Role.reader.backendName,
+            },
+            parseResponse: any(named: 'parseResponse'),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('Success keeps selected role', (tester) async {
+        when(
+          () => client.performApptiveLink<bool>(
+            link: inviteLink,
+            body: any(named: 'body'),
+            parseResponse: any(named: 'parseResponse'),
+          ),
+        ).thenAnswer((invocation) async {
+          final parser =
+              invocation.namedArguments[const Symbol('parseResponse')]
+                  as Future<bool> Function(Response);
+
+          return parser(Response('Invitation send', 200));
+        });
+        await tester.pumpWidget(target);
+        await tester.pumpAndSettle();
+
+        showSpaceInvitationDialog(context: context, space: space);
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextFormField), email);
+
+        await tester.tap(find.text('Manage'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Read only').last);
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Send'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Read only'), findsOneWidget);
+      });
+
+      testWidgets('Only allows defined roles', (tester) async {
+        await tester.pumpWidget(target);
+        await tester.pumpAndSettle();
+
+        showSpaceInvitationDialog(
+          context: context,
+          space: space,
+          allowedRoles: [
+            Role.reader,
+            Role.writer,
+          ],
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Read only'), findsOneWidget);
+        await tester.tap(find.text('Read only'));
+        await tester.pumpAndSettle();
+        expect(find.text('Manage'), findsNothing);
+        // 2 For Selected Builder and Items
+        expect(find.text('Read only'), findsNWidgets(2));
+        expect(find.text('Edit entries'), findsNWidgets(2));
+        expect(
+          (find.byType(DropdownButton<Role>).evaluate().first.widget
+                  as DropdownButton)
+              .items!
+              .length,
+          2,
+        );
+      });
+
+      testWidgets('Only one allowed role hides selection', (tester) async {
+        when(
+          () => client.performApptiveLink<bool>(
+            link: inviteLink,
+            body: any(named: 'body'),
+            parseResponse: any(named: 'parseResponse'),
+          ),
+        ).thenAnswer((invocation) async {
+          final parser =
+              invocation.namedArguments[const Symbol('parseResponse')]
+                  as Future<bool> Function(Response);
+
+          return parser(Response('Invitation send', 200));
+        });
+        await tester.pumpWidget(target);
+        await tester.pumpAndSettle();
+
+        showSpaceInvitationDialog(
+          context: context,
+          space: space,
+          allowedRoles: [
+            Role.admin,
+          ],
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(DropdownButton<Role>), findsNothing);
+
+        await tester.enterText(find.byType(TextFormField), email);
+
+        await tester.tap(find.text('Send'));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => client.performApptiveLink<bool>(
+            link: inviteLink,
+            body: {
+              'email': email,
+              'role': Role.admin.backendName,
+            },
+            parseResponse: any(named: 'parseResponse'),
+          ),
+        ).called(1);
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Adding a InvitationDialog Heinzelman with configuration options for Invitation Method and Available Roles as well as providing a way of customising displayed Strings
- **Note** This uses a git dependency on changes that add the invite link and models for `Roles` as that is not yet released. (Waiting for Model for Invitiations)