### PR TITLE
ci: Use Conventional GitFor PR Titles

### DIFF
--- a/.github/workflows/pr_title_check.yml
+++ b/.github/workflows/pr_title_check.yml
@@ -1,0 +1,16 @@
+name: 'PR Title is Conventional'
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use conventional git title tags so that melos can handle versioning automatically