### PR TITLE
feat: AppVersion.offset

### DIFF
--- a/packages/zweidenker_heinzelmen/lib/src/app_version.dart
+++ b/packages/zweidenker_heinzelmen/lib/src/app_version.dart
@@ -67,9 +67,9 @@ class _AppVersionState extends State<AppVersion> {
 
 /// Gets the Version Number with an unscrambled Build Number
 /// And returns it as Major.Minor.Patch+BuildNumber
-Future<String> getVersionInfo(
-    [String Function(PackageInfo) displayBuildNumber =
-        _unscrambleBuildNumber]) {
+Future<String> getVersionInfo([
+  String Function(PackageInfo) displayBuildNumber = _unscrambleBuildNumber,
+]) {
   return PackageInfo.fromPlatform().then((value) {
     return '${value.version}+${displayBuildNumber.call(value)}';
   });

--- a/packages/zweidenker_heinzelmen/lib/src/app_version.dart
+++ b/packages/zweidenker_heinzelmen/lib/src/app_version.dart
@@ -16,7 +16,7 @@ class AppVersion extends StatefulWidget {
 
   /// Creates a TextWidget to show the output of [getVersionString] with [textStyle]
   /// The displayed Build Number will be the result of the raw build number - offset
-  factory AppVersion.withOffset({
+  factory AppVersion.offset({
     Key? key,
     TextStyle? textStyle,
     int offset = 0,

--- a/packages/zweidenker_heinzelmen/lib/src/app_version.dart
+++ b/packages/zweidenker_heinzelmen/lib/src/app_version.dart
@@ -42,9 +42,9 @@ class _AppVersionState extends State<AppVersion> {
   String? _versionString;
 
   @override
-  void initState() {
-    super.initState();
-    getVersionInfo().then((version) {
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    getVersionInfo(widget._calculateDisplayBuildNumber).then((version) {
       _versionString = version;
       if (mounted) {
         setState(() {});
@@ -63,14 +63,16 @@ class _AppVersionState extends State<AppVersion> {
       return const SizedBox();
     }
   }
+}
 
-  /// Gets the Version Number with an unscrambled Build Number
-  /// The method of how
-  Future<String> getVersionInfo() {
-    return PackageInfo.fromPlatform().then((value) {
-      return '${value.version}+${widget._calculateDisplayBuildNumber(value)}';
-    });
-  }
+/// Gets the Version Number with an unscrambled Build Number
+/// And returns it as Major.Minor.Patch+BuildNumber
+Future<String> getVersionInfo(
+    [String Function(PackageInfo) displayBuildNumber =
+        _unscrambleBuildNumber]) {
+  return PackageInfo.fromPlatform().then((value) {
+    return '${value.version}+${displayBuildNumber.call(value)}';
+  });
 }
 
 /// Gets the Version Number with an unscrambled Build Number

--- a/packages/zweidenker_heinzelmen/lib/src/app_version.dart
+++ b/packages/zweidenker_heinzelmen/lib/src/app_version.dart
@@ -1,14 +1,38 @@
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
-/// Shows the AppVersion String as Major.Minor.Patch.Build Number based on the output of [getVersionInfo]
+/// Shows the AppVersion String as Major.Minor.Patch.Build+Number based on the output of [getVersionInfo]
 class AppVersion extends StatefulWidget {
+  const AppVersion._({
+    super.key,
+    this.textStyle,
+    required String Function(PackageInfo) calculateDisplayBuildNumber,
+  }) : _calculateDisplayBuildNumber = calculateDisplayBuildNumber;
+
   /// Creates a TextWidget to show the output of [getVersionString] with [textStyle]
   /// During loading the build method will return a [SizedBox]
-  const AppVersion({super.key, this.textStyle});
+  const AppVersion({super.key, this.textStyle})
+      : _calculateDisplayBuildNumber = _unscrambleBuildNumber;
+
+  /// Creates a TextWidget to show the output of [getVersionString] with [textStyle]
+  /// The displayed Build Number will be the result of the raw build number - offset
+  factory AppVersion.withOffset({
+    Key? key,
+    TextStyle? textStyle,
+    int offset = 0,
+  }) {
+    return AppVersion._(
+      key: key,
+      textStyle: textStyle,
+      calculateDisplayBuildNumber: (info) =>
+          _unscrambleWithOffset(info, offset: offset),
+    );
+  }
 
   /// TextStyle the Version will be shown with
   final TextStyle? textStyle;
+
+  final String Function(PackageInfo) _calculateDisplayBuildNumber;
 
   @override
   State<AppVersion> createState() => _AppVersionState();
@@ -39,6 +63,14 @@ class _AppVersionState extends State<AppVersion> {
       return const SizedBox();
     }
   }
+
+  /// Gets the Version Number with an unscrambled Build Number
+  /// The method of how
+  Future<String> getVersionInfo() {
+    return PackageInfo.fromPlatform().then((value) {
+      return '${value.version}+${widget._calculateDisplayBuildNumber(value)}';
+    });
+  }
 }
 
 /// Gets the Version Number with an unscrambled Build Number
@@ -49,13 +81,7 @@ class _AppVersionState extends State<AppVersion> {
 ///  Patch * 10000 +
 ///  uniqueBuildNumber
 ///
-/// CI code is here: https://github.com/zweidenker/flutter_workflows/blob/main/.github/scripts/generate_build_number.sh
-Future<String> getVersionInfo() {
-  return PackageInfo.fromPlatform().then((value) {
-    return '${value.version}+${_unscrambleBuildNumber(value)}';
-  });
-}
-
+/// CI code is here: https://github.com/zweidenker/flutter_workflows/blob/v1/.github/scripts/generate_build_number.sh
 String _unscrambleBuildNumber(PackageInfo info) {
   final packagedBuildNumber = int.parse(info.buildNumber);
 
@@ -68,4 +94,14 @@ String _unscrambleBuildNumber(PackageInfo info) {
           versions[1] * 1000000 -
           versions[2] * 10000)
       .toString();
+}
+
+/// Gets the Version Number with an unscrambled Build Number
+/// The scrambling of the version is used bei the ZWEIDENKER CI Pipelines
+/// The generation is:
+/// Offset + unique Build Number
+String _unscrambleWithOffset(PackageInfo info, {required int offset}) {
+  final packagedBuildNumber = int.parse(info.buildNumber);
+
+  return (packagedBuildNumber - offset).toString();
 }

--- a/packages/zweidenker_heinzelmen/test/src/app_version_test.dart
+++ b/packages/zweidenker_heinzelmen/test/src/app_version_test.dart
@@ -62,7 +62,7 @@ void main() {
     group('Version Number Widget', () {
       testWidgets('Shows Sized Box while loading', (tester) async {
         await tester.pumpWidget(
-          AppVersion.withOffset(
+          AppVersion.offset(
             offset: 102030000,
           ),
         );
@@ -82,7 +82,7 @@ void main() {
 
         await tester.pumpWidget(
           MaterialApp(
-            home: AppVersion.withOffset(
+            home: AppVersion.offset(
               offset: 102030000,
               textStyle: textStyle,
             ),

--- a/packages/zweidenker_heinzelmen/test/src/app_version_test.dart
+++ b/packages/zweidenker_heinzelmen/test/src/app_version_test.dart
@@ -4,55 +4,96 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:zweidenker_heinzelmen/zweidenker_heinzelmen.dart';
 
 void main() {
-  setUpAll(() {
-    PackageInfo.setMockInitialValues(
-      appName: 'appName',
-      packageName: 'packageName',
-      version: '1.2.3',
-      buildNumber: '102030081',
-      buildSignature: 'buildSignature',
-    );
-  });
-
   const formattedVersion = '1.2.3+81';
 
-  group('Parse version Number', () {
-    test('Get Version Number, unscrambles buildNumber', () async {
-      final version = await getVersionInfo();
+  group('Factored Version', () {
+    setUpAll(() {
+      PackageInfo.setMockInitialValues(
+        appName: 'appName',
+        packageName: 'packageName',
+        version: '1.2.3',
+        buildNumber: '102030081',
+        buildSignature: 'buildSignature',
+      );
+    });
+    group('Version Number Widget', () {
+      testWidgets('Shows Sized Box while loading', (tester) async {
+        await tester.pumpWidget(const AppVersion());
 
-      expect(version, equals(formattedVersion));
+        expect(find.byType(SizedBox), findsOneWidget);
+      });
+
+      testWidgets('Shows Version Number as Text', (tester) async {
+        await tester.pumpWidget(const MaterialApp(home: AppVersion()));
+        await tester.pump();
+
+        expect(find.text(formattedVersion), findsOneWidget);
+      });
+
+      testWidgets('Provided Style gets applied', (tester) async {
+        const textStyle = TextStyle(fontWeight: FontWeight.bold);
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: AppVersion(
+              textStyle: textStyle,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final textWidget =
+            find.text(formattedVersion).evaluate().first.widget as Text;
+        expect(textWidget.style, equals(textStyle));
+      });
     });
   });
 
-  group('Version Number Widget', () {
-    testWidgets('Shows Sized Box while loading', (tester) async {
-      await tester.pumpWidget(const AppVersion());
-
-      expect(find.byType(SizedBox), findsOneWidget);
-    });
-
-    testWidgets('Shows Version Number as Text', (tester) async {
-      await tester.pumpWidget(const MaterialApp(home: AppVersion()));
-      await tester.pump();
-
-      expect(find.text(formattedVersion), findsOneWidget);
-    });
-
-    testWidgets('Provided Style gets applied', (tester) async {
-      const textStyle = TextStyle(fontWeight: FontWeight.bold);
-
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: AppVersion(
-            textStyle: textStyle,
-          ),
-        ),
+  group('Offset Version', () {
+    setUpAll(() {
+      PackageInfo.setMockInitialValues(
+        appName: 'appName',
+        packageName: 'packageName',
+        version: '1.2.3',
+        buildNumber: '102030081',
+        buildSignature: 'buildSignature',
       );
-      await tester.pump();
+    });
+    group('Version Number Widget', () {
+      testWidgets('Shows Sized Box while loading', (tester) async {
+        await tester.pumpWidget(
+          AppVersion.withOffset(
+            offset: 102030000,
+          ),
+        );
 
-      final textWidget =
-          find.text(formattedVersion).evaluate().first.widget as Text;
-      expect(textWidget.style, equals(textStyle));
+        expect(find.byType(SizedBox), findsOneWidget);
+      });
+
+      testWidgets('Shows Version Number as Text', (tester) async {
+        await tester.pumpWidget(const MaterialApp(home: AppVersion()));
+        await tester.pump();
+
+        expect(find.text(formattedVersion), findsOneWidget);
+      });
+
+      testWidgets('Provided Style gets applied', (tester) async {
+        const textStyle = TextStyle(fontWeight: FontWeight.bold);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AppVersion.withOffset(
+              offset: 102030000,
+              textStyle: textStyle,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final textWidget =
+            find.text(formattedVersion).evaluate().first.widget as Text;
+        expect(textWidget.style, equals(textStyle));
+      });
     });
   });
 }


### PR DESCRIPTION
Add a named constructor to the `AppVersion` Heinzelmen used to display the correct AppVersion if the Build Number was generated with the changes from https://github.com/zweidenker/flutter_workflows/pull/7